### PR TITLE
[Hotfix] - Fix unnecessary scan limit changes

### DIFF
--- a/src/atama/head/process/head.cpp
+++ b/src/atama/head/process/head.cpp
@@ -218,14 +218,14 @@ void Head::scan_two_direction()
     scan_pan_angle = get_pan_angle();
     scan_tilt_angle = get_tilt_angle();
 
-    scan_position = (scan_mode == control::SCAN_DOWN) ? 0 : 1;
+    scan_position = (scan_mode == control::SCAN_DOWN) ? 0 : 2;
 
-    if (pan_angle < (scan_left_limit + scan_right_limit) / 2) {
+    if (pan_angle <= (scan_left_limit + scan_right_limit) / 2) {
       scan_direction = 0;
-      scan_pan_angle -= std::fabs(scan_right_limit);
+      scan_pan_angle = scan_right_limit;
     } else {
       scan_direction = 1;
-      scan_pan_angle += std::fabs(scan_right_limit);
+      scan_pan_angle = scan_left_limit;
     }
   }
 
@@ -278,9 +278,6 @@ void Head::process()
           if (init_scanning()) {
             scan_pan_angle = get_pan_angle();
             scan_tilt_angle = get_tilt_angle();
-            
-            scan_left_limit = 0;
-            scan_right_limit = 0;
 
             if (get_tilt_angle() < (scan_bottom_limit + scan_top_limit) / 2) {
               scan_position = 0;


### PR DESCRIPTION
## Jira Link: 

## Description

The setting of left and right scan limit in `vertical_scan()` to 0 makes the scan limit for other scan changes to 0 too, thus becomes a bug. Removed the unnecessary and not used change of scan_limit in `vertical_scan()`.

## Type of Change

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.