### PR TITLE
[Enhancement] Change vertical scan to start from top

### DIFF
--- a/src/atama/head/process/head.cpp
+++ b/src/atama/head/process/head.cpp
@@ -280,13 +280,6 @@ void Head::process()
             scan_pan_angle = get_pan_angle();
             scan_tilt_angle = get_tilt_angle();
 
-            // if (get_tilt_angle() < (scan_bottom_limit + scan_top_limit) / 2) {
-            //   scan_position = 0;
-            //   scan_tilt_angle -= (fabs(scan_top_limit - scan_bottom_limit) / 2);
-            // } else {
-            //   scan_position = 1;
-            //   scan_tilt_angle += (fabs(scan_top_limit - scan_bottom_limit) / 2);
-            // }
             scan_position = 1;
             scan_tilt_angle += (fabs(scan_top_limit - scan_bottom_limit) / 2);
           }

--- a/src/atama/head/process/head.cpp
+++ b/src/atama/head/process/head.cpp
@@ -280,13 +280,15 @@ void Head::process()
             scan_pan_angle = get_pan_angle();
             scan_tilt_angle = get_tilt_angle();
 
-            if (get_tilt_angle() < (scan_bottom_limit + scan_top_limit) / 2) {
-              scan_position = 0;
-              scan_tilt_angle -= (fabs(scan_top_limit - scan_bottom_limit) / 2);
-            } else {
-              scan_position = 1;
-              scan_tilt_angle += (fabs(scan_top_limit - scan_bottom_limit) / 2);
-            }
+            // if (get_tilt_angle() < (scan_bottom_limit + scan_top_limit) / 2) {
+            //   scan_position = 0;
+            //   scan_tilt_angle -= (fabs(scan_top_limit - scan_bottom_limit) / 2);
+            // } else {
+            //   scan_position = 1;
+            //   scan_tilt_angle += (fabs(scan_top_limit - scan_bottom_limit) / 2);
+            // }
+            scan_position = 1;
+            scan_tilt_angle += (fabs(scan_top_limit - scan_bottom_limit) / 2);
           }
 
           scan_pan_angle = (scan_left_limit + scan_right_limit) / 2;

--- a/src/atama/head/process/head.cpp
+++ b/src/atama/head/process/head.cpp
@@ -281,7 +281,7 @@ void Head::process()
             scan_tilt_angle = get_tilt_angle();
 
             scan_position = 1;
-            scan_tilt_angle += (fabs(scan_top_limit - scan_bottom_limit) / 2);
+            scan_tilt_angle += fabs(scan_top_limit - scan_bottom_limit);
           }
 
           scan_pan_angle = (scan_left_limit + scan_right_limit) / 2;


### PR DESCRIPTION
## Jira Link: 

## Description

Change the vertical scan to start from top to help with detecting far ball after kick. 

## Type of Change

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.